### PR TITLE
Proposal to keep Deadbeat Reward exclusive to the original Relic Collector

### DIFF
--- a/precursorracekrakoth_redemptionpatch/recipes/atprk_relicexchange/atprk_relicpackdeadbeat.recipe
+++ b/precursorracekrakoth_redemptionpatch/recipes/atprk_relicexchange/atprk_relicpackdeadbeat.recipe
@@ -6,5 +6,5 @@
     "item" : "atprk_relicpackdeadbeat",
     "count" : 1
   },
-  "groups" : [ "atprk_relicexchange", "atprk_relicexchange_penguin", "nouncrafting" ]
+  "groups" : [ "atprk_relicexchange", "nouncrafting" ]
 }


### PR DESCRIPTION
While I can see the logic behind adding it to the Penguin Relic Collector's offers, I think it'd be best to keep the Deadbeat Reward as it was, since I feel it'd distract a bit from the Annelisk focus of the Penguin Relic Collector and given that I see the Deadbeat Reward as a kind of surrogate for the Glitch, and thus representing the 4th servant species on its own in a way.

Alternatively however, this could be given to the Novakid Relic Seeker to balance things out so to speak, assuming that my proposed switchover of their Erchius Spook capture pod has been accepted. All up to you at the end of the day.