### PR TITLE
Proposal to adjust Precursor Reward loot

### DIFF
--- a/precursorracekrakoth_fupatch/treasure/atprk_furewards.treasurepools
+++ b/precursorracekrakoth_fupatch/treasure/atprk_furewards.treasurepools
@@ -7,8 +7,8 @@
   "atprk_furelicpackprecursor" : [
     [1, {
       "fill" : [
-        {"item" : [ "precursorterminal", 1]},
-        {"item" : [ "protheonshard", 1]},
+        {"item" : [ "precursordroppod", 1]},
+        {"item" : [ "pprecursorcannonnew", 1]},
         {"item" : [ "money", 4000]},
         {"item" : [ "fuscienceresource", 3000]}
       ]


### PR DESCRIPTION
I think giving the Precursor Packed Reward the rarest Precursor weapon and decorative object would bring the reward more in line with the other ones here, and also make more sense.