### PR TITLE
Proposal to adjust Precursor Reward loot

### DIFF
--- a/precursorracekrakoth_fupatch/treasure/atprk_furewards.treasurepools
+++ b/precursorracekrakoth_fupatch/treasure/atprk_furewards.treasurepools
@@ -8,7 +8,7 @@
     [1, {
       "fill" : [
         {"item" : [ "precursorterminal", 1]},
-        {"item" : [ "protheonshard", 1]},
+        {"item" : [ "precursorcannonnew", 1]},
         {"item" : [ "money", 4000]},
         {"item" : [ "fuscienceresource", 3000]}
       ]


### PR DESCRIPTION
Figured that it'd make more sense for one to receive the rarest Precursor weapon as a reward rather than a Protheon Shard, if only to bring the packed reward more in-line with the others.