### PR TITLE
Proposal to change object requirement for Precursor reward

### DIFF
--- a/precursorracekrakoth_fupatch/recipes/atprk_relicexchange/atprk_furelicpackprecursor.recipe
+++ b/precursorracekrakoth_fupatch/recipes/atprk_relicexchange/atprk_furelicpackprecursor.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "spacetimeobeliskinactive", "count" : 1 }
+    { "item" : "precursordroppod", "count" : 1 }
   ],
   "output" : {
     "item" : "atprk_furelicpackprecursor",


### PR DESCRIPTION
Since the reward now gives out the rarest, and potentially most powerful Precursor weapon now, I feel like the item turned in for it should be appropriately rare and more explicitly Precursor related than the obelisk. Feel free to disregard this if you think the obelisk is sufficiently rare enough though.