### PR TITLE
Reverting item requirement for Precursor Packed Reward

### DIFF
--- a/precursorracekrakoth_fupatch/recipes/atprk_relicexchange/atprk_furelicpackprecursor.recipe
+++ b/precursorracekrakoth_fupatch/recipes/atprk_relicexchange/atprk_furelicpackprecursor.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "precursordroppod", "count" : 1 }
+    { "item" : "spacetimeobeliskinactive", "count" : 1 }
   ],
   "output" : {
     "item" : "atprk_furelicpackprecursor",


### PR DESCRIPTION
Realized that it'd be nicer for the Precursor reward to give out the rarest decorative item rather than the Precursor version of the Pixel Printer, as that would bring it nicely in line with all the other Packed Rewards, therefore I decided to revert the item requirement back to what it originally needed.