### PR TITLE
Simulation Report addendum

### DIFF
--- a/precursorracekrakoth_redemptionpatch/codex/other/atprk_deadbeatreport.codex
+++ b/precursorracekrakoth_redemptionpatch/codex/other/atprk_deadbeatreport.codex
@@ -6,16 +6,19 @@
   "icon" : "atprk_deadbeatreport.png",
   "contentPages" : [
   "Simulacrum group: A
-Status: Terminated - simulation deemed a failure due to hivemind model not accurately emulating society.
+Status: Terminated - Simulation deemed a failure due to hivemind model not accurately emulating society.
 
 Simulacrum group: B
-Status: Extinct - simulacrum eventually realized their true nature and elected to collectively self-terminate.",
+Status: Extinct - Simulacrum eventually realized their true nature and elected to collectively self-terminate.",
 
 "Simulacrum group: C
-Status: Extinct - simulation achieved technological level comparable to ours. Suffered societal collapse from over-extended logistics brought on by excessive colonization.
+Status: Extinct - Simulation achieved technological level comparable to ours. Suffered societal collapse from over-extended logistics brought on by excessive colonization.
 
 Simulacrum group: D
-Status: Active - unforeseen programming error led to inability to advance technologically beyond early stage. Patching deemed too costly and impractical. Considering adaptation into a control group to save on funding."
+Status: Active - Unforeseen programming error led to inability to advance technologically beyond early stage. Patching deemed too costly and impractical. Considering adaptation into a control group to save on funding.",
+
+"Simulacrum group: ^cyan;^white;
+Status: Unknown - Contact with group lost after apparent, and impressive, success. All subsequent attempts at regaining contact have met with failure in spite of evidence of continued activity."
   ],
     "itemConfig" : {
     "rarity" : "rare",


### PR DESCRIPTION
Given that the entire reason I settled on there being 4 entries in this codex was because of how it originally was crafted with 4 data fragments, I felt that this would be a good opportunity to add a bonus entry to account for needing 5 data fragments to craft now. Admittedly this addendum does imply that the Ancients are a successful group of Glitch/Simulacrum (which also means that the Deadbeat predate the Ancients), so you're free to disregard this if it doesn't quite work for you.