### PR TITLE
Adding Impervium to Chthonian moons

### DIFF
--- a/precursorracekrakoth_redemptionpatch/biomes/oredistributions.configfunctions.patch
+++ b/precursorracekrakoth_redemptionpatch/biomes/oredistributions.configfunctions.patch
@@ -4,19 +4,39 @@
 		"path" : "/atprk_chthoniansurface/0/1/-",
 		"value" : [ "platinum", 0.00 ]
 	},
+        {
+		"op" : "add",
+		"path" : "/atprk_chthoniansurface/0/1/-",
+		"value" : [ "r-impervium", 0.00 ]
+	},
 	{
 		"op" : "add",
 		"path" : "/atprk_chthoniandepth1/0/1/-",
 		"value" :  ["platinum", 0.15 ]
+	},
+        {
+		"op" : "add",
+		"path" : "/atprk_chthoniandepth1/0/1/-",
+		"value" :  [ "r-impervium", 0.10 ]
 	},
 	{
 		"op" : "add",
 		"path" : "/atprk_chthoniandepth2/0/1/-",
 		"value" : [ "platinum", 0.25 ]
 	},
+        {
+		"op" : "add",
+		"path" : "/atprk_chthoniandepth2/0/1/-",
+		"value" : [ "r-impervium", 0.20 ]
+	},
 	{
 		"op" : "add",
 		"path" : "/atprk_chthoniandepth3/0/1/-",
 		"value" : [ "platinum", 0.45 ]
+	},
+        {
+		"op" : "add",
+		"path" : "/atprk_chthoniandepth3/0/1/-",
+		"value" : [ "r-impervium", 0.25 ]
 	}
 ]


### PR DESCRIPTION
Figured it'd be nice for Impervium to spawn on these moons to make them more worthwhile to visit, makes sense on account of meteors being involved in the formation of these moons, which often carry Impervium on them in Project Redemption